### PR TITLE
Adding srun command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ sbatch << EOF
 #SBATCH --job-name            name
 #SBATCH --output              %A_%a.out
 
-python demo.py \$SLURM_ARRAY_TAKSK_ID
+python demo.py \$SLURM_ARRAY_TASK_ID
 
 EOF
 ```

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -123,12 +123,17 @@ class Testing(unittest.TestCase):
         )
         self.assertEqual(self.script, str(slurm))
 
-    def test_13_output_env_vars(self):
-        self.assertEqual(Slurm.SLURM_ARRAY_TASK_ID, r'$SLURM_ARRAY_TASK_ID')
-
     def test_12_output_env_vars_object(self):
         slurm = Slurm()
         self.assertEqual(slurm.SLURM_ARRAY_TASK_ID, r'$SLURM_ARRAY_TASK_ID')
+
+    def test_13_output_env_vars(self):
+        self.assertEqual(Slurm.SLURM_ARRAY_TASK_ID, r'$SLURM_ARRAY_TASK_ID')
+
+    def test_14_srun_returncode(self):
+        slurm = Slurm()
+        code = slurm.srun('echo Hello!')
+        self.assertEqual(code, 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #1 by adding support for simple `srun` command by not piping stdout. Command is blocking and streams output until completion. Also added a unit test case and fixed a typo in the README.